### PR TITLE
ci - Fix DB healthcheck in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     networks:
       - app_net
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", $POSTGRES_DB]
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 5s
       timeout: 20s
       retries: 5


### PR DESCRIPTION
Healthcheck was failing with error
FATAL:  role "root" does not exist